### PR TITLE
fix(anthropic): sanitize cross-provider tool call ids and thinking signatures

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -132,7 +132,7 @@ Generated navigation for every package-local documentation page. This index inte
 | command | `bg-clear` | `command:bg-clear` | `src/extension.ts:559` |
 | command | `bg-tasks` | `command:bg-tasks` | `src/extension.ts:551` |
 | command | `bg-update` | `command:bg-update` | `src/extension.ts:567` |
-| command | `claude-cache` | `command:claude-cache` | `src/core/anthropic-attribution.ts:1928` |
+| command | `claude-cache` | `command:claude-cache` | `src/core/anthropic-attribution.ts:1942` |
 | command | `fusion` | `command:fusion` | `src/fusion-extension.ts:996` |
 | command | `fusion-models` | `command:fusion-models` | `src/fusion-extension.ts:1029` |
 | command | `jobs` | `command:jobs` | `src/extension.ts:605` |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -132,7 +132,7 @@ Generated navigation for every package-local documentation page. This index inte
 | command | `bg-clear` | `command:bg-clear` | `src/extension.ts:559` |
 | command | `bg-tasks` | `command:bg-tasks` | `src/extension.ts:551` |
 | command | `bg-update` | `command:bg-update` | `src/extension.ts:567` |
-| command | `claude-cache` | `command:claude-cache` | `src/core/anthropic-attribution.ts:1942` |
+| command | `claude-cache` | `command:claude-cache` | `src/core/anthropic-attribution.ts:1979` |
 | command | `fusion` | `command:fusion` | `src/fusion-extension.ts:996` |
 | command | `fusion-models` | `command:fusion-models` | `src/fusion-extension.ts:1029` |
 | command | `jobs` | `command:jobs` | `src/extension.ts:605` |

--- a/docs/commands/claude-cache.md
+++ b/docs/commands/claude-cache.md
@@ -12,7 +12,7 @@ covers_sources: []
 <!-- pi-docs:begin name="command-contract-claude-cache" generator="scripts/docs/generate.mjs" -->
 | Command | Description | Provenance |
 | --- | --- | --- |
-| `/claude-cache` | Show or set Claude cache retention for this session (short, long, default) | `src/core/anthropic-attribution.ts:1942` |
+| `/claude-cache` | Show or set Claude cache retention for this session (short, long, default) | `src/core/anthropic-attribution.ts:1979` |
 <!-- pi-docs:end name="command-contract-claude-cache" -->
 
 Show or change the Anthropic cache-retention preference for the current session.

--- a/docs/commands/claude-cache.md
+++ b/docs/commands/claude-cache.md
@@ -12,7 +12,7 @@ covers_sources: []
 <!-- pi-docs:begin name="command-contract-claude-cache" generator="scripts/docs/generate.mjs" -->
 | Command | Description | Provenance |
 | --- | --- | --- |
-| `/claude-cache` | Show or set Claude cache retention for this session (short, long, default) | `src/core/anthropic-attribution.ts:1928` |
+| `/claude-cache` | Show or set Claude cache retention for this session (short, long, default) | `src/core/anthropic-attribution.ts:1942` |
 <!-- pi-docs:end name="command-contract-claude-cache" -->
 
 Show or change the Anthropic cache-retention preference for the current session.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -902,7 +902,7 @@
         "id": "command:claude-cache",
         "kind": "command",
         "name": "claude-cache",
-        "source": "src/core/anthropic-attribution.ts:1928"
+        "source": "src/core/anthropic-attribution.ts:1942"
       },
       {
         "description": "Start fixed-purpose Fusion reason in the background and return immediately.",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -902,7 +902,7 @@
         "id": "command:claude-cache",
         "kind": "command",
         "name": "claude-cache",
-        "source": "src/core/anthropic-attribution.ts:1942"
+        "source": "src/core/anthropic-attribution.ts:1979"
       },
       {
         "description": "Start fixed-purpose Fusion reason in the background and return immediately.",

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -48,7 +48,7 @@ This generated registry lists production environment-variable references, runtim
 | `PI_BG_REGISTRY_URL` | read | `src/extension.ts:464` |
 | `PI_BG_SHELL` | read | `src/core/common.ts:722` |
 | `PI_BG_SHELL_PATH` | read | `src/core/common.ts:723` |
-| `PI_CACHE_RETENTION` | read, write | `src/core/anthropic-attribution.ts:587`<br>`src/core/fusion/claude-cache.ts:57`<br>`src/core/fusion/pi-child.ts:273`<br>`src/core/fusion/pi-child.ts:274` |
+| `PI_CACHE_RETENTION` | read, write | `src/core/anthropic-attribution.ts:595`<br>`src/core/fusion/claude-cache.ts:57`<br>`src/core/fusion/pi-child.ts:273`<br>`src/core/fusion/pi-child.ts:274` |
 | `PI_FUSION_CANDIDATE_OUTPUT_RECOVERY_PATH` | read, remove, write | `src/core/fusion/pi-child.ts:100`<br>`src/core/fusion/pi-child.ts:1879`<br>`src/fusion-child-extension.ts:599` |
 | `PI_FUSION_RESEARCH_ENABLED` | read, remove, write | `src/core/fusion/pi-child.ts:100`<br>`src/core/fusion/pi-child.ts:1902`<br>`src/fusion-child-extension.ts:608` |
 | `PI_FUSION_SOURCE_POLICY_PATH` | read, remove, write | `src/core/fusion/pi-child.ts:100`<br>`src/core/fusion/pi-child.ts:1903`<br>`src/fusion-child-extension.ts:555` |
@@ -61,7 +61,7 @@ This generated registry lists production environment-variable references, runtim
 | `PI_SESSION_FILE` | remove | `src/core/delegate/launch.ts:330`<br>`src/core/fusion/pi-child.ts:100` |
 | `PI_SESSION_ID` | remove | `src/core/delegate/launch.ts:330`<br>`src/core/fusion/pi-child.ts:100` |
 | `PI_SKIP_VERSION_CHECK` | write | `src/core/delegate/launch.ts:352`<br>`src/core/fusion/pi-child.ts:272` |
-| `PIPELINE_ANTHROPIC_ATTRIBUTION_AUDIT_PATH` | read | `src/core/anthropic-attribution.ts:1013` |
+| `PIPELINE_ANTHROPIC_ATTRIBUTION_AUDIT_PATH` | read | `src/core/anthropic-attribution.ts:1021` |
 | `SHELL` | read | `src/core/common.ts:718` |
 | `SystemRoot` | read | `src/core/windows-taskkill.ts:96` |
 | `WINDIR` | read | `src/core/windows-taskkill.ts:101` |

--- a/src/core/anthropic-attribution.ts
+++ b/src/core/anthropic-attribution.ts
@@ -1173,6 +1173,20 @@ function markLastConversationCacheSurface(
   return output;
 }
 
+// Anthropic requires `tool_use.id` and `tool_result.tool_use_id` to match
+// `^[a-zA-Z0-9_-]+$` (max 64 chars). Histories inherited from other providers do not
+// always satisfy that: the OpenAI Responses API (openai-codex, github-copilot) emits
+// pipe-separated `call_xxx|fc_yyy` identifiers. Replaying such a history to Anthropic
+// fails the whole request with `400 invalid_request_error`, and because the offending
+// id stays in the conversation, every later turn keeps failing.
+//
+// Normalize the same way pi's built-in Anthropic transport does, so a cross-provider
+// history stays replayable. Applied to tool calls and tool results alike; the mapping
+// is deterministic, so a result still pairs with its originating call.
+function normalizeAnthropicToolCallId(id: string): string {
+  return id.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64);
+}
+
 function convertMessages(
   messages: readonly PiMessage[],
   cacheControl?: AnthropicCacheControl,
@@ -1228,7 +1242,7 @@ function convertMessages(
         ) {
           content.push({
             type: 'tool_use',
-            id: block['id'],
+            id: normalizeAnthropicToolCallId(block['id']),
             name: block['name'],
             input: block['arguments'] ?? {},
           });
@@ -1239,7 +1253,7 @@ function convertMessages(
       const toolResults: JsonObject[] = [
         {
           type: 'tool_result',
-          tool_use_id: message.toolCallId,
+          tool_use_id: normalizeAnthropicToolCallId(message.toolCallId),
           content: convertContentBlocks(message.content),
           is_error: message.isError === true,
         },
@@ -1249,7 +1263,7 @@ function convertMessages(
         const next = messages[lookahead] as Extract<PiMessage, { role: 'toolResult' }>;
         toolResults.push({
           type: 'tool_result',
-          tool_use_id: next.toolCallId,
+          tool_use_id: normalizeAnthropicToolCallId(next.toolCallId),
           content: convertContentBlocks(next.content),
           is_error: next.isError === true,
         });

--- a/src/core/anthropic-attribution.ts
+++ b/src/core/anthropic-attribution.ts
@@ -358,7 +358,15 @@ type PiContentBlock =
 
 type PiMessage =
   | { readonly role: 'user'; readonly content: string | readonly PiContentBlock[] }
-  | { readonly role: 'assistant'; readonly content: readonly JsonObject[] }
+  | {
+      readonly role: 'assistant';
+      readonly content: readonly JsonObject[];
+      // Pi records which model produced an assistant turn. Required to decide whether an
+      // opaque `thinking` signature can be replayed or must be dropped as foreign.
+      readonly provider?: string;
+      readonly api?: string;
+      readonly model?: string;
+    }
   | {
       readonly role: 'toolResult';
       readonly toolCallId: string;
@@ -1187,7 +1195,29 @@ function normalizeAnthropicToolCallId(id: string): string {
   return id.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64);
 }
 
+// A `thinking` signature is an opaque provider-issued attestation over the reasoning
+// payload. Anthropic verifies it and rejects anything it did not mint:
+//
+//   messages.1.content.0: Invalid `signature` in `thinking` block
+//
+// Reasoning inherited from another provider carries a foreign payload (the OpenAI
+// Responses API stores `{"id":"rs_..."}` in this field), so it can never validate.
+// Treat a signature as replayable only when the message was produced by the very same
+// provider/api/model we are now calling, mirroring pi's built-in Anthropic transport.
+function isReplayableThinkingSource(
+  model: PiModelLike,
+  message: Extract<PiMessage, { role: 'assistant' }>,
+): boolean {
+  const policy = resolveClaudeCodeModelPolicy(model);
+  return (
+    message.provider === model.provider &&
+    message.api === model.api &&
+    (message.model === model.id || message.model === policy.modelId)
+  );
+}
+
 function convertMessages(
+  model: PiModelLike,
   messages: readonly PiMessage[],
   cacheControl?: AnthropicCacheControl,
 ): JsonObject[] {
@@ -1223,18 +1253,25 @@ function convertMessages(
           block['text'].trim().length > 0
         ) {
           content.push({ type: 'text', text: sanitizeSurrogates(block['text']) });
-        } else if (
-          block['type'] === 'thinking' &&
-          typeof block['thinking'] === 'string' &&
-          block['thinking'].trim().length > 0
-        ) {
+        } else if (block['type'] === 'thinking' && typeof block['thinking'] === 'string') {
           const signature =
             typeof block['thinkingSignature'] === 'string' ? block['thinkingSignature'] : '';
-          content.push(
-            signature.length > 0
-              ? { type: 'thinking', thinking: sanitizeSurrogates(block['thinking']), signature }
-              : { type: 'text', text: sanitizeSurrogates(block['thinking']) },
-          );
+          const replayable = signature.length > 0 && isReplayableThinkingSource(model, message);
+          // Redacted thinking is opaque ciphertext with no readable text to fall back on,
+          // so it is either replayed verbatim to its issuer or dropped entirely.
+          if (block['redacted'] === true) {
+            if (replayable) content.push({ type: 'redacted_thinking', data: signature });
+          } else if (replayable) {
+            content.push({
+              type: 'thinking',
+              thinking: sanitizeSurrogates(block['thinking']),
+              signature,
+            });
+          } else if (block['thinking'].trim().length > 0) {
+            // Foreign or unsigned reasoning: keep the human-readable content as plain text
+            // so the turn is not silently lost, but never claim an unverifiable signature.
+            content.push({ type: 'text', text: sanitizeSurrogates(block['thinking']) });
+          }
         } else if (
           block['type'] === 'toolCall' &&
           typeof block['id'] === 'string' &&
@@ -1341,7 +1378,7 @@ export function buildAnthropicRequestParams(
   const cacheControl = resolveAnthropicCacheControl(model, options);
   const params: JsonObject = {
     model: policy.modelId,
-    messages: convertMessages(context.messages, cacheControl),
+    messages: convertMessages(model, context.messages, cacheControl),
     max_tokens: maxTokens,
     stream: true,
   };

--- a/tests/unit/anthropic-attribution.test.ts
+++ b/tests/unit/anthropic-attribution.test.ts
@@ -242,6 +242,66 @@ void describe('global Anthropic attribution extension', () => {
     assert.ok(serialized.includes(nativeId), 'native Anthropic ids must survive verbatim');
   });
 
+  void it('drops thinking signatures inherited from another provider', () => {
+    // The OpenAI Responses API stores its own reasoning payload in this field.
+    // Anthropic verifies signatures it minted and 400s on anything else.
+    const foreignSignature = '{"id":"rs_09b95e17b7805346016a879b86a10087d0a9ffe5de6fbbb86a"}';
+    const params = buildAnthropicRequestParams(
+      { provider: 'anthropic', api: 'anthropic-messages', id: 'claude-sonnet-4-5', maxTokens: 64_000, reasoning: true },
+      {
+        messages: [
+          { role: 'user', content: 'think about it' },
+          {
+            role: 'assistant',
+            provider: 'openai-codex',
+            api: 'openai-codex-responses',
+            model: 'gpt-5.6-sol',
+            content: [
+              { type: 'thinking', thinking: 'weighing options', thinkingSignature: foreignSignature },
+            ],
+          },
+        ],
+      },
+    );
+
+    const serialized = JSON.stringify(params);
+    assert.ok(!serialized.includes('rs_09b95e17'), 'foreign signature must never be replayed');
+    assert.ok(!serialized.includes('"signature"'), 'no signature may be claimed for foreign reasoning');
+    // The reasoning text is still worth keeping, just not as a signed thinking block.
+    assert.ok(serialized.includes('weighing options'), 'reasoning text should degrade to plain text');
+  });
+
+  void it('replays thinking signatures minted by the same Anthropic model', () => {
+    const nativeSignature = 'ErUBCkYIBRgCIkDr3gL9dJj2';
+    const params = buildAnthropicRequestParams(
+      { provider: 'anthropic', api: 'anthropic-messages', id: 'claude-sonnet-4-5', maxTokens: 64_000, reasoning: true },
+      {
+        messages: [
+          { role: 'user', content: 'think about it' },
+          {
+            role: 'assistant',
+            provider: 'anthropic',
+            api: 'anthropic-messages',
+            model: 'claude-sonnet-4-5',
+            content: [
+              { type: 'thinking', thinking: 'weighing options', thinkingSignature: nativeSignature },
+            ],
+          },
+        ],
+      },
+    );
+
+    const messages = params['messages'];
+    assert.ok(Array.isArray(messages));
+    const assistant = messages.find((entry) => isJsonObject(entry) && entry['role'] === 'assistant');
+    assert.ok(isJsonObject(assistant));
+    const content = assistant['content'];
+    assert.ok(Array.isArray(content));
+    const thinking = content.find((block) => isJsonObject(block) && block['type'] === 'thinking');
+    assert.ok(isJsonObject(thinking), 'same-model thinking must stay a signed thinking block');
+    assert.equal(thinking['signature'], nativeSignature);
+  });
+
   void it('allows exactly one independently loaded copy to own global registration', () => {
     const bus = new SynchronousTestBus();
     const first = recordingHost(bus);

--- a/tests/unit/anthropic-attribution.test.ts
+++ b/tests/unit/anthropic-attribution.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import spawnAnthropicAttribution, {
   ANTHROPIC_ATTRIBUTION_CLAIM_CHANNEL,
+  buildAnthropicRequestParams,
   rewriteAnthropicRequestPayload,
   type PiExtensionHost,
   type PiContextLike,
@@ -174,6 +175,71 @@ void describe('global Anthropic attribution extension', () => {
       () => buildAttestedPiArgv({ ...base, provider: 'anthropic' }),
       /require the package attribution extension/,
     );
+  });
+
+  void it('normalizes inherited cross-provider tool call ids to the Anthropic id pattern', () => {
+    // OpenAI Responses providers (openai-codex, github-copilot) emit `call_xxx|fc_yyy`.
+    // Anthropic rejects the `|`, so replaying a cross-provider history 400s forever.
+    const inheritedId = `call_MSQFOxA4zvg6xxQpPJhHG7lJ|fc_${'0'.repeat(96)}`;
+    const params = buildAnthropicRequestParams(
+      { provider: 'anthropic', id: 'claude-sonnet-4-5', maxTokens: 64_000, reasoning: true },
+      {
+        messages: [
+          { role: 'user', content: 'run it' },
+          {
+            role: 'assistant',
+            content: [{ type: 'toolCall', id: inheritedId, name: 'bash', arguments: { cmd: 'ls' } }],
+          },
+          { role: 'toolResult', toolCallId: inheritedId, content: [{ type: 'text', text: 'ok' }] },
+        ],
+      },
+    );
+
+    const anthropicToolCallId = /^[a-zA-Z0-9_-]+$/;
+    const messages = params['messages'];
+    assert.ok(Array.isArray(messages));
+
+    const toolUseIds: string[] = [];
+    const toolResultIds: string[] = [];
+    for (const message of messages) {
+      assert.ok(isJsonObject(message));
+      const content = message['content'];
+      if (!Array.isArray(content)) continue;
+      for (const block of content) {
+        assert.ok(isJsonObject(block));
+        if (block['type'] === 'tool_use') toolUseIds.push(String(block['id']));
+        if (block['type'] === 'tool_result') toolResultIds.push(String(block['tool_use_id']));
+      }
+    }
+
+    assert.deepEqual(toolUseIds.length, 1);
+    assert.deepEqual(toolResultIds.length, 1);
+    for (const id of [...toolUseIds, ...toolResultIds]) {
+      assert.match(id, anthropicToolCallId);
+      assert.ok(id.length <= 64, `id must respect the 64 character limit, got ${id.length}`);
+    }
+    // A result is only usable if it still points at its originating call.
+    assert.equal(toolResultIds[0], toolUseIds[0]);
+  });
+
+  void it('keeps tool call ids that already satisfy the Anthropic pattern unchanged', () => {
+    const nativeId = 'toolu_01A09q90qw90lq917835lq9';
+    const params = buildAnthropicRequestParams(
+      { provider: 'anthropic', id: 'claude-sonnet-4-5', maxTokens: 64_000, reasoning: true },
+      {
+        messages: [
+          { role: 'user', content: 'run it' },
+          {
+            role: 'assistant',
+            content: [{ type: 'toolCall', id: nativeId, name: 'bash', arguments: {} }],
+          },
+          { role: 'toolResult', toolCallId: nativeId, content: [{ type: 'text', text: 'ok' }] },
+        ],
+      },
+    );
+
+    const serialized = JSON.stringify(params);
+    assert.ok(serialized.includes(nativeId), 'native Anthropic ids must survive verbatim');
   });
 
   void it('allows exactly one independently loaded copy to own global registration', () => {


### PR DESCRIPTION
## Summary

Replaying a conversation that contains turns inherited from a non-Anthropic provider makes **every** subsequent Anthropic request in that session fail. Two independent 400s, same root cause:

```
messages.1.content.1.tool_use.id: String should match pattern '^[a-zA-Z0-9_-]+$'
messages.1.content.0: Invalid `signature` in `thinking` block
```

Both come from `convertMessages` copying provider-specific fields verbatim into an Anthropic payload.

## Why this is more than a one-off error

The offending block is part of the stored conversation, so it is re-sent on every later turn. Once a user switches model mid-session — Codex for one turn, then back to Claude — that session is bricked; each subsequent message 400s. Starting a new session is currently the only workaround.

## Root cause

Pi's built-in Anthropic transport guards against both cases by routing history through `transformMessages(...)`, which normalizes tool-call ids and applies an `isSameModel` rule to thinking blocks.

This extension deliberately replaces that transport with its own `/v1/messages?beta=true` builder to apply Claude Code OAuth attribution and cache policy — and in doing so loses both guards. The attribution behaviour is correct; only the message sanitization is missing.

## Fix 1 — tool call ids

Anthropic requires `tool_use.id` / `tool_result.tool_use_id` to match `^[a-zA-Z0-9_-]+$` (max 64). The OpenAI Responses API (`openai-codex`, `github-copilot`) emits `call_xxx|fc_yyy`.

```ts
function normalizeAnthropicToolCallId(id: string): string {
  return id.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 64);
}
```

Deterministic, so a `tool_result` still pairs with its `tool_use`. The lookahead loop that coalesces consecutive tool results is included — normalizing only the leading result would unpair the rest. Native `toolu_…` ids pass through byte-identical.

## Fix 2 — thinking signatures

A `thinking` signature is an opaque provider-issued attestation; Anthropic verifies it and rejects anything it did not mint. The previous code replayed **any** non-empty `thinkingSignature` as a signed block. Inherited reasoning carries a foreign payload — the OpenAI Responses API stores `{"id":"rs_..."}` there — which can never validate.

A signature is now replayed only when the assistant turn came from the same provider/api/model being called. Foreign reasoning degrades to plain text so the turn isn't silently lost; redacted thinking is opaque ciphertext with no readable fallback, so it is replayed verbatim to its issuer or dropped.

This required `PiMessage` to carry the optional `provider`/`api`/`model` provenance that pi already persists on assistant messages (verified against session records: `['api','content','model','provider','role','stopReason',…]`).

## Tests

Four cases added to `tests/unit/anthropic-attribution.test.ts`, driven through the exported `buildAnthropicRequestParams` rather than private helpers:

- cross-provider tool ids become pattern-valid within 64 chars, result still pairs with its call
- native Anthropic tool ids survive verbatim
- foreign thinking signatures are never replayed, but the reasoning text is preserved
- same-model thinking signatures are replayed intact

I confirmed each regression test actually fails without its fix (reverting fix 1 → `fail 1`; reverting fix 2 → `fail 1`), so neither can silently rot.

## Verification

- `npm run typecheck` — clean
- `npm test` — full gate, 7 suites, 571 tests, 0 failures
- `npm run docs:verify` — clean, after `npm run docs:generate`

The `docs/` edits are generated output only. The freshness gate pins source line numbers and adding the helpers shifted them; regenerating was required for CI. No authored prose changed.

Validated against 420 real local session files: **36,472 invalid tool ids → 0** (no truncation collisions, no orphaned tool results), and **11,069 foreign thinking signatures** identified as affected.
