### PR TITLE
fix(pi-launch): fall back to the running host CLI when no pi is on PATH

### DIFF
--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -33,7 +33,7 @@ This generated registry lists production environment-variable references, runtim
 | `OPENROUTER_BASE_URL` | remove | `src/core/attested-pi-run.ts:135`<br>`src/core/fusion/pi-child.ts:100` |
 | `path` | read | `src/core/common.ts:681` |
 | `Path` | read | `src/core/common.ts:681` |
-| `PATH` | read | `src/core/common.ts:681` |
+| `PATH` | read | `src/core/common.ts:681`<br>`src/core/pi-launch.ts:142` |
 | `PI_API_BASE_URL` | remove | `src/core/attested-pi-run.ts:135`<br>`src/core/fusion/pi-child.ts:100` |
 | `PI_API_KEY` | remove | `src/core/attested-pi-run.ts:135`<br>`src/core/fusion/pi-child.ts:100` |
 | `PI_AUTH_FILE` | remove | `src/core/attested-pi-run.ts:135`<br>`src/core/fusion/pi-child.ts:100` |

--- a/src/core/pi-launch.ts
+++ b/src/core/pi-launch.ts
@@ -1,7 +1,7 @@
 import { readFileSync, realpathSync, statSync } from 'node:fs';
 import type { Stats } from 'node:fs';
 import { createRequire } from 'node:module';
-import { dirname, extname, isAbsolute, join, relative, sep } from 'node:path';
+import { delimiter, dirname, extname, isAbsolute, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 export interface PiLaunchSpec {
@@ -13,6 +13,8 @@ export interface PiLaunchSpec {
 export interface PiLaunchDependencies {
   readonly platform?: NodeJS.Platform;
   readonly execPath?: string;
+  readonly hostScript?: string;
+  readonly path?: string;
   readonly resolvePackageJson?: (specifier: string) => string;
   readonly readFile?: (path: string) => string | Buffer;
   readonly realpath?: (path: string) => string;
@@ -134,9 +136,50 @@ function pathInside(parent: string, child: string): boolean {
   return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel) && !rel.split(sep).includes('..'));
 }
 
+// A standalone `pi` on PATH stays the preferred launcher.
+export function hasPiExecutable(deps: { platform?: NodeJS.Platform; path?: string } = {}): boolean {
+  const platform = deps.platform ?? process.platform;
+  const rawPath = deps.path ?? process.env['PATH'] ?? '';
+  const suffixes = platform === 'win32' ? ['.exe', '.cmd', '.bat'] : [''];
+  for (const dir of rawPath.split(delimiter)) {
+    if (!dir) continue;
+    for (const suffix of suffixes) {
+      try {
+        if (statSync(join(dir, `pi${suffix}`)).isFile()) return true;
+      } catch {
+        // absent here; keep scanning
+      }
+    }
+  }
+  return false;
+}
+
+// The process that loaded this extension is itself a Pi CLI, so it can launch the
+// child when no standalone `pi` is installed: npx runs, project-local installs,
+// and rebranded hosts all land here.
+function resolveHostSelfLaunch(deps: PiLaunchDependencies): PiLaunchSpec {
+  const execPath = deps.execPath ?? process.execPath;
+  const hostScript = deps.hostScript ?? process.argv[1];
+  const realpath = deps.realpath ?? realpathSync;
+  const stat = deps.stat ?? statSync;
+  if (!hostScript) failResolution('no `pi` on PATH and the host CLI script path is unavailable');
+  // Resolve first: the launcher is usually a bin symlink whose own name carries no extension.
+  const targetReal = readPath('host CLI realpath', hostScript, () => realpath(hostScript));
+  const extension = extname(targetReal).toLowerCase();
+  if (extension !== '.js' && extension !== '.cjs' && extension !== '.mjs')
+    failResolution(`no \`pi\` on PATH and the host CLI is not a node entry point: ${targetReal}`);
+  const targetStat = readPath('host CLI stat', targetReal, () => stat(targetReal));
+  if (!targetStat.isFile()) failResolution('host CLI script is not a regular file');
+  return { executable: execPath, argvPrefix: [targetReal], kind: 'package-node-cli' };
+}
+
 export function resolvePiLaunch(deps: PiLaunchDependencies = {}): PiLaunchSpec {
   const platform = deps.platform ?? process.platform;
-  if (platform !== 'win32') return { executable: 'pi', argvPrefix: [], kind: 'path' };
+  if (platform !== 'win32') {
+    if (hasPiExecutable({ platform, ...(deps.path === undefined ? {} : { path: deps.path }) }))
+      return { executable: 'pi', argvPrefix: [], kind: 'path' };
+    return resolveHostSelfLaunch(deps);
+  }
 
   const resolvePackageJson = deps.resolvePackageJson ?? defaultResolvePackageJson;
   const readFile = deps.readFile ?? readFileSync;

--- a/tests/unit/pi-launch.test.ts
+++ b/tests/unit/pi-launch.test.ts
@@ -53,17 +53,59 @@ async function removeFixture(root: string): Promise<void> {
 }
 
 void describe('Pi launch resolution', () => {
-  void it('returns the bare path form on POSIX without package lookup', () => {
-    let resolved = false;
-    const spec = resolvePiLaunch({
-      platform: 'darwin',
-      resolvePackageJson: () => {
-        resolved = true;
-        throw new Error('should not run');
-      },
-    });
-    assert.deepEqual(spec, { executable: 'pi', argvPrefix: [], kind: 'path' });
-    assert.equal(resolved, false);
+  void it('returns the bare path form on POSIX when pi is on PATH, without package lookup', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pi-launch-path-'));
+    try {
+      await writeNestedFile(join(root, 'pi'), '#!/bin/sh\n');
+      let resolved = false;
+      const spec = resolvePiLaunch({
+        platform: 'darwin',
+        path: root,
+        resolvePackageJson: () => {
+          resolved = true;
+          throw new Error('should not run');
+        },
+      });
+      assert.deepEqual(spec, { executable: 'pi', argvPrefix: [], kind: 'path' });
+      assert.equal(resolved, false);
+    } finally {
+      await removeFixture(root);
+    }
+  });
+
+  void it('falls back to the running host CLI on POSIX when pi is absent', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pi-launch-host-'));
+    try {
+      const hostScript = join(root, 'dist', 'cli.js');
+      await writeNestedFile(hostScript, '#!/usr/bin/env node\n');
+      const spec = resolvePiLaunch({
+        platform: 'darwin',
+        path: join(root, 'empty-bin'),
+        execPath: '/usr/bin/node',
+        hostScript,
+      });
+      assert.deepEqual(spec, {
+        executable: '/usr/bin/node',
+        argvPrefix: [realpathSync(hostScript)],
+        kind: 'package-node-cli',
+      });
+    } finally {
+      await removeFixture(root);
+    }
+  });
+
+  void it('fails closed on POSIX when neither pi nor a node host CLI is available', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'pi-launch-none-'));
+    try {
+      const hostScript = join(root, 'bin', 'launcher.sh');
+      await writeNestedFile(hostScript, '#!/bin/sh\n');
+      assert.throws(
+        () => resolvePiLaunch({ platform: 'darwin', path: join(root, 'empty-bin'), hostScript }),
+        /pi_executable_resolution_failed/,
+      );
+    } finally {
+      await removeFixture(root);
+    }
   });
 
   void it('resolves a Windows string bin JavaScript CLI through Node', async () => {


### PR DESCRIPTION
## Problem

`resolvePiLaunch()` assumes a standalone `pi` executable on `PATH` for every non-Windows host:

```ts
if (platform !== 'win32') return { executable: 'pi', argvPrefix: [], kind: 'path' };
```

Wherever the CLI is not installed globally, `bg_delegate`, the Fusion tools, and `bg_run_pi_attested` are advertised to the model but every call fails at spawn. That covers `npx` invocations, project-local installs, and hosts that ship the same agent under a different binary name.

Observed on such a host:

```
pi_executable_resolution_failed: no `pi` on PATH and the host CLI is not a node entry point: …/bin/<host>
```

## Fix

The process that loads this extension is itself a Pi CLI, so it can launch the child. A standalone `pi` on `PATH` still wins; only when none is found does resolution fall back to the running host script (`process.argv[1]`), spawned through `process.execPath` — the same `package-node-cli` shape the Windows branch already produces.

Two details worth calling out:

- The launcher is usually a bin **symlink whose own name carries no extension**, so the script is realpath-resolved *before* the node entry-point check. Checking the raw path first rejects every normal installation.
- Resolution still fails closed: if neither route yields a `.js`/`.cjs`/`.mjs` entry point, `PiLaunchResolutionError` is raised as before.

`PATH` is injectable through `PiLaunchDependencies` so resolution stays deterministic under test. Worth noting: the existing POSIX test passed only because npm prepends `node_modules/.bin`, which contains a `pi` shim from the dev dependency — outside npm there is no `pi`, so the assertion was environment-dependent.

## Verification

- New tests: `pi` present → bare path form (no package lookup); `pi` absent → host-self form; neither → `pi_executable_resolution_failed`.
- Negative control: with `src/core/pi-launch.ts` stashed and the tests kept, `tests/unit/pi-launch.test.ts` reports 8 pass / 2 fail. With the change, 10/10.
- Full unit suite: 444/444, `npm run typecheck` clean.
- `docs/reference/runtime-contracts.md` regenerated with `npm run docs:generate`; `docs:verify` reports deterministic generation OK and `tests/unit/docs-gate.test.ts` is green.
