### PR TITLE
fix(anthropic): add Claude Code model policy for claude-fable-5-1

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -132,7 +132,7 @@ Generated navigation for every package-local documentation page. This index inte
 | command | `bg-clear` | `command:bg-clear` | `src/extension.ts:559` |
 | command | `bg-tasks` | `command:bg-tasks` | `src/extension.ts:551` |
 | command | `bg-update` | `command:bg-update` | `src/extension.ts:567` |
-| command | `claude-cache` | `command:claude-cache` | `src/core/anthropic-attribution.ts:1928` |
+| command | `claude-cache` | `command:claude-cache` | `src/core/anthropic-attribution.ts:1933` |
 | command | `fusion` | `command:fusion` | `src/fusion-extension.ts:996` |
 | command | `fusion-models` | `command:fusion-models` | `src/fusion-extension.ts:1029` |
 | command | `jobs` | `command:jobs` | `src/extension.ts:605` |

--- a/docs/commands/claude-cache.md
+++ b/docs/commands/claude-cache.md
@@ -12,7 +12,7 @@ covers_sources: []
 <!-- pi-docs:begin name="command-contract-claude-cache" generator="scripts/docs/generate.mjs" -->
 | Command | Description | Provenance |
 | --- | --- | --- |
-| `/claude-cache` | Show or set Claude cache retention for this session (short, long, default) | `src/core/anthropic-attribution.ts:1928` |
+| `/claude-cache` | Show or set Claude cache retention for this session (short, long, default) | `src/core/anthropic-attribution.ts:1933` |
 <!-- pi-docs:end name="command-contract-claude-cache" -->
 
 Show or change the Anthropic cache-retention preference for the current session.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -902,7 +902,7 @@
         "id": "command:claude-cache",
         "kind": "command",
         "name": "claude-cache",
-        "source": "src/core/anthropic-attribution.ts:1928"
+        "source": "src/core/anthropic-attribution.ts:1933"
       },
       {
         "description": "Start fixed-purpose Fusion reason in the background and return immediately.",

--- a/docs/reference/runtime-contracts.md
+++ b/docs/reference/runtime-contracts.md
@@ -48,7 +48,7 @@ This generated registry lists production environment-variable references, runtim
 | `PI_BG_REGISTRY_URL` | read | `src/extension.ts:464` |
 | `PI_BG_SHELL` | read | `src/core/common.ts:722` |
 | `PI_BG_SHELL_PATH` | read | `src/core/common.ts:723` |
-| `PI_CACHE_RETENTION` | read, write | `src/core/anthropic-attribution.ts:587`<br>`src/core/fusion/claude-cache.ts:57`<br>`src/core/fusion/pi-child.ts:273`<br>`src/core/fusion/pi-child.ts:274` |
+| `PI_CACHE_RETENTION` | read, write | `src/core/anthropic-attribution.ts:592`<br>`src/core/fusion/claude-cache.ts:57`<br>`src/core/fusion/pi-child.ts:273`<br>`src/core/fusion/pi-child.ts:274` |
 | `PI_FUSION_CANDIDATE_OUTPUT_RECOVERY_PATH` | read, remove, write | `src/core/fusion/pi-child.ts:100`<br>`src/core/fusion/pi-child.ts:1879`<br>`src/fusion-child-extension.ts:599` |
 | `PI_FUSION_RESEARCH_ENABLED` | read, remove, write | `src/core/fusion/pi-child.ts:100`<br>`src/core/fusion/pi-child.ts:1902`<br>`src/fusion-child-extension.ts:608` |
 | `PI_FUSION_SOURCE_POLICY_PATH` | read, remove, write | `src/core/fusion/pi-child.ts:100`<br>`src/core/fusion/pi-child.ts:1903`<br>`src/fusion-child-extension.ts:555` |
@@ -61,7 +61,7 @@ This generated registry lists production environment-variable references, runtim
 | `PI_SESSION_FILE` | remove | `src/core/delegate/launch.ts:330`<br>`src/core/fusion/pi-child.ts:100` |
 | `PI_SESSION_ID` | remove | `src/core/delegate/launch.ts:330`<br>`src/core/fusion/pi-child.ts:100` |
 | `PI_SKIP_VERSION_CHECK` | write | `src/core/delegate/launch.ts:352`<br>`src/core/fusion/pi-child.ts:272` |
-| `PIPELINE_ANTHROPIC_ATTRIBUTION_AUDIT_PATH` | read | `src/core/anthropic-attribution.ts:1013` |
+| `PIPELINE_ANTHROPIC_ATTRIBUTION_AUDIT_PATH` | read | `src/core/anthropic-attribution.ts:1018` |
 | `SHELL` | read | `src/core/common.ts:718` |
 | `SystemRoot` | read | `src/core/windows-taskkill.ts:96` |
 | `WINDIR` | read | `src/core/windows-taskkill.ts:101` |

--- a/src/core/anthropic-attribution.ts
+++ b/src/core/anthropic-attribution.ts
@@ -209,6 +209,11 @@ const CLAUDE_CODE_MODEL_POLICIES: Record<string, ClaudeCodeModelPolicy> = Object
     CLAUDE_CODE_ADAPTIVE_200K_BETA,
     'adaptive-effort',
   ),
+  'claude-fable-5-1': claudeCode200KSubscriptionPolicy(
+    'claude-fable-5-1',
+    CLAUDE_CODE_ADAPTIVE_200K_BETA,
+    'adaptive-effort',
+  ),
   'claude-haiku-4-5': claudeCode200KSubscriptionPolicy(
     'claude-haiku-4-5',
     CLAUDE_CODE_BETA,

--- a/src/core/context/token-budget.ts
+++ b/src/core/context/token-budget.ts
@@ -137,6 +137,7 @@ export const TOKEN_BUDGET_FAMILY_CALIBRATIONS: Readonly<
 const MODEL_OVERRIDES: Readonly<Record<string, TokenBudgetFamily>> = Object.freeze({
   'anthropic/claude-opus-5': 'anthropic',
   'anthropic/claude-fable-5': 'anthropic',
+  'anthropic/claude-fable-5-1': 'anthropic',
   'openai-codex/gpt-5.6-sol': 'openai-codex',
   'openai-codex/gpt-5.6-terra': 'openai-codex',
   'openai-codex/gpt-5.5': 'openai-codex',

--- a/tests/unit/anthropic-attribution.test.ts
+++ b/tests/unit/anthropic-attribution.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import spawnAnthropicAttribution, {
   ANTHROPIC_ATTRIBUTION_CLAIM_CHANNEL,
+  resolveClaudeCodeModelPolicy,
   rewriteAnthropicRequestPayload,
   type PiExtensionHost,
   type PiContextLike,
@@ -191,5 +192,22 @@ void describe('global Anthropic attribution extension', () => {
     assert.equal(second.registrations.handlers, 0);
     assert.equal(second.registrations.providers, 0);
     assert.equal(bus.listenerCount(ANTHROPIC_ATTRIBUTION_CLAIM_CHANNEL), 1);
+  });
+
+  void it('resolves claude-fable-5-1 to the adaptive 200K subscription policy', () => {
+    for (const id of ['claude-fable-5-1', 'anthropic/claude-fable-5-1']) {
+      const policy = resolveClaudeCodeModelPolicy({ provider: 'anthropic', id });
+      assert.equal(policy.modelId, 'claude-fable-5-1');
+      assert.equal(policy.thinkingPolicy, 'adaptive-effort');
+      assert.equal(policy.contextWindow, 200_000);
+      assert.deepEqual(
+        policy.beta,
+        resolveClaudeCodeModelPolicy({ provider: 'anthropic', id: 'claude-fable-5' }).beta,
+      );
+    }
+    assert.throws(
+      () => resolveClaudeCodeModelPolicy({ provider: 'anthropic', id: 'claude-fable-9' }),
+      /has no Claude Code model policy for claude-fable-9/,
+    );
   });
 });


### PR DESCRIPTION
## Problem

Anthropic now serves `claude-fable-5-1` (it is listed in `GET /v1/models` and the pi.dev model catalog carries it since earendil-works/pi#8987), but `CLAUDE_CODE_MODEL_POLICIES` in `src/core/anthropic-attribution.ts` only knows `claude-fable-5`. Selecting the new model in Pi with this package installed fails before any request is sent:

```
Anthropic attribution has no Claude Code model policy for claude-fable-5-1
```

## Change

- Register `claude-fable-5-1` with the same adaptive-effort 200K subscription policy (`CLAUDE_CODE_ADAPTIVE_200K_BETA`) as `claude-fable-5`.
- Add the matching `anthropic/claude-fable-5-1` entry to the token-budget `MODEL_OVERRIDES`.
- Pin the resolution in `tests/unit/anthropic-attribution.test.ts`: both bare and `anthropic/`-prefixed ids resolve to the adaptive policy with the `claude-fable-5` beta set, and an unknown id still throws.
- Regenerate docs (`npm run docs:generate`); the only generated-doc changes are shifted provenance line numbers for `/claude-cache` and the env-var table.

No other behavior changes. The 200K subscription context policy and 1M-beta refusal are unchanged.

## Verification

- `npm run typecheck`: clean
- `npm run docs:verify`: `31 surfaces, 50 sources, deterministic generation OK`
- `npm run test:unit`: 446 tests, 0 failures

Note for reviewers: with the policy in place the request now reaches Anthropic and is rejected server-side with `claude_code_version_too_old` (requires Claude Code 2.1.251 or newer). That is a separate matter for the maintainer of the attribution constants and is intentionally out of scope here; this PR only removes the client-side policy gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
